### PR TITLE
Run without any configuration when it is used immediately after installation

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -80,7 +80,7 @@ pub struct Config {
 impl Config {
     pub fn new(config_path: Option<&Path>) -> Result<Self> {
         let config_path: &Path = config_path.unwrap_or_else(|| &*CONFIG_PATH);
-        if !config_path.is_file() {
+        if config_path.exists() && !config_path.is_file() {
             return Err(anyhow!(
                 "Failed to load configuration file (config_path = {})",
                 config_path.display()
@@ -88,7 +88,11 @@ impl Config {
         }
 
         let mut content = String::new();
-        fs::File::open(config_path)?.read_to_string(&mut content)?;
+
+        if config_path.exists() {
+            fs::File::open(config_path)?.read_to_string(&mut content)?;
+        }
+
         let data = ::toml::from_str(&content)?;
 
         Ok(Config {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -7,7 +7,7 @@ use crate::{
     repository::Repository,
     vcs::{self, Vcs},
 };
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use glob::Pattern;
 use std::{
     fmt::Arguments,
@@ -164,7 +164,7 @@ impl Workspace {
     pub fn for_each_repo<F: Fn(&Repository) -> Result<()>>(&self, f: F) -> Result<()> {
         let repos = self
             .repositories()
-            .ok_or_else(|| anyhow!("The cache has not initialized yet"))?;
+            .unwrap_or_else(|| &[][..]);
         for repo in repos {
             f(&repo)?;
         }


### PR DESCRIPTION
Thanks for your great package. I like this package so much that I create [Emacs client for `rhq`](https://github.com/ROCKTAKEY/rhq).

This PR have 2 changes. These changes allow us to use full features of `rhq` without any configuration.
- `config.toml` becomes unnecessary to run
- Cache become unnecessary  to run `rhq list`

#  `config.toml` becomes unnecessary to run
`rhq` needs `config.toml`, but it may be often annoying  because `rhq` can be used without any configuration. For example, I use it without any configuration, so I just `touch` `~/.config/rhq/config.toml` before use.
On this PR, `rhq` just uses empty configuration when `config.toml` does not exist.

# Cache becomes unnecessary  to run `rhq list`
`rhq list` needs cache. However, the cache has repositories added only by `rhq`, so nonexistence of cache means no repositories are added,
On this PR, `rhq` regards absence of cache as no repositories.